### PR TITLE
Adding docs, structural improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/build/
+docs/source/generated/
 
 # PyBuilder
 .pybuilder/

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ cython_debug/
 # stuff specific to this repo
 Figures/
 Outputs/
+
+# thing that appeareared once
+.DS_Store

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,4 @@
+# Contributors
+ - [Charlotte Summers] (https://github.com/csummers25) Research Support Officer, Department of Earth Sciences. Utrecht University
+ 
+ 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ Various model setups can be found in the `models` directory.  In each sub-direct
 To run a given setup, change the import statement for the `initializeModel` function in `main.py` to point to the directory of the model you wish to run.  For example, to run the model in the directory `lithosphereExtension`, we change the import statement in `main.py` to `from models.lithosphereExtension.setup import initializeModel`.
 
 ## Creating your own model
-To create your own setup, you must create a new directory in `models` and populate it with an implementation of `setup.py` and `material_properties*.txt`.  `setup.py` must contain the function `initializeModel` (see the docstring of the example implementations for details on what it should return), which sets the initial conditions, boundary conditions and parameter values for the simulation.  We recommend that you start by copying an existing `setup.py` and then modifying it for your own implementation.
-
-## Authors
-__Charlotte Summers__  
-Research Support Officer, Department of Earth Sciences
-Utrecht University 
-email: c.summers [at] uu.nl  
+To create your own setup, you must create a new directory in `models` and populate it with an implementation of `setup.py` and `material_properties*.txt`.  `setup.py` must contain the function `initializeModel` (see the docstring of the example implementations for details on what it should return), which sets the initial conditions, boundary conditions and parameter values for the simulation.  We recommend that you start by copying an existing `setup.py` and then modifying it for your own implementation. 
 
 ## References
 [1] Gerya T. MATLAB program examples. In: Introduction to Numerical Geodynamic Modelling. Cambridge University Press; 2019:425-437. DOI: https://doi.org/10.1017/9781316534243.024 

--- a/dataStructures.py
+++ b/dataStructures.py
@@ -9,92 +9,6 @@ import numpy as np
 from numba import jit, float64, int64
 from numba.experimental import jitclass
 
-spec_par = [
-    ('gx', float64),
-    ('gy', float64),
-    ('Rgas', float64),
-    ('T_top', float64),
-    ('T_bot', float64),
-    ('v_ext', float64),
-    ('eta_min', float64),
-    ('eta_max', float64),
-    ('stress_min', float64),
-    ('eta_wt', float64),
-    ('max_pow_law', float64),
-    ('t_end', float64),
-    ('ntstp_max', int64),
-    ('Temp_stp_max', int64),
-    ('tstp_max', float64),
-    ('marker_max', float64),
-    ('marker_sch', int64),
-    ('movemode', int64),
-    ('dsubgrid', float64),
-    ('dsubgridT', float64),
-    ('frict_yn', float64),
-    ('adia_yn', float64),
-    ('bx', float64),
-    ('by', float64),
-    ('Nx', int64),
-    ('Ny', int64),
-    ('non_uni_xsize', float64),
-    ('save_output', int64),
-    ('save_fig', int64),
-]
-@jitclass(spec_par)
-class Parameters():
-    
-    # creates parameters object
-    def __init__(self):
-        
-        # physical constants
-        self.gx = 0.0                           # x-direction gravitational acc
-        self.gy = 9.81                          # y-direction gravitational acc
-        self.Rgas = 8.314                       # gas constant
-        
-        # physical model setup
-        self.T_top = 273                        # temperature at the top face of the model (K)
-        self.T_bot = 1750                       # temperature at the bottom face of the model (K)
-        self.v_ext = 2.0/(100*365.25*24*3600)   # extension velocity of the grid (cm/yr)
-        
-        # viscosity model
-        self.eta_min = 1e18                     # minimum viscosity
-        self.eta_max = 1e25                     # maximum viscosity
-        self.stress_min = 1e4                   # minimum stress
-        self.eta_wt = 0                         # viscosity weighting, for (old?) visco-plastic model
-        self.max_pow_law = 150                  # maximum power law exponent in visc model
-        
-        
-        # timestepping
-        self.t_end = 72e3/self.v_ext            # end time
-        self.ntstp_max = 360                    # maximum number of timesteps
-        self.Temp_stp_max = 20                  # maximum number of temperature substeps
-        
-        self.tstp_max = 1e4*365.25*24*3600      # maximum timestep
-        
-        # marker options
-        self.marker_max = 0.3                   # maximum marker movement per timestep (fraction of av. grid step)
-        self.marker_sch = 4                     # marker scheme 0 = no movement, 1 = Euler, 4=RK4
-        
-        self.movemode = 0                       # velocity calculation 0 = momentum eqn, 1 = solid body (not working currently)
-        
-        # subgrid diffusion
-        self.dsubgrid = 1                       # subgrid stress coeff (none if zero)
-        self.dsubgridT = 1                      # subgrid diffusion coeff(none if zero)
-        
-        # switches for heating terms
-        self.frict_yn = 1                       # use friction heating?
-        self.adia_yn = 1                        # use adiabatic heating?
-        
-        # grid spacing params
-        self.bx = 2000                          # x-grid spacing in high res area
-        self.by = 2000                          # y-grid spacing in high res area
-        self.Nx = 30                            # number of unevenly spaced grid points either side of high res zone
-        self.Ny = 20                            # number of unvenly spaced grid points below high res zone
-        self.non_uni_xsize = 100000             # physical x-size of non-uniform grid region
-        
-        # output options
-        self.save_output = 50                        # number of steps between output files
-        self.save_fig = 20                            # number of steps between figure output
 
 
 spec_mark = [
@@ -120,9 +34,69 @@ spec_mark = [
 
 @jitclass(spec_mark)
 class Markers():
+    '''
+    Class which stores all properties of markers in arrays.
+    
+    Attributes
+    ----------
+    xnum : INT
+        Number of markers in x-direction, in initial configuration.
+    ynum : INT
+        Number of markers in y-direction, in initial configuration.
+    num : INT
+        Total number of markers (xnum*ynum)
+    x : ARRAY
+        Marker x-coordinates
+    y : ARRAY
+        Marker y-coordinates
+    T : ARRAY
+        Marker temperatures
+    id : ARRAY
+        Marker material type identifier
+    nx : ARRAY
+        Marker horizontal grid index of nearest top-left node
+    ny : ARRAY
+        Marker vertical grid index of the nearest top-left node
+    sigmaxx : ARRAY
+        Marker normal stress
+    sigmaxy : ARRAY
+        Marker shear stress
+    eta : ARRAY
+        Marker viscosity
+    epsxx : ARRAY
+        Marker normal strain rate
+    epsxy : ARRAY
+        Markers shear strain rate
+    P : ARRAY
+        Marker pressure
+    gII : ARRAY
+        Marker accumulated strain
+    E_rat : ARRAY
+        eii_marker/eii_grid ratio.
+    epsii : ARRAY
+        Marker deviatoric strain rate
+    
+    
+    '''
     
     # creates empty marker property arrays
     def __init__(self, numx, numy):
+        '''
+        Constructor for the markers object, which creates zeroed arrays for all
+        properties, ready to be intialized by an implementation of initialize_markers
+
+        Parameters
+        ----------
+        numx : INT
+            Number of markers in x-direction in initial grid configuration.
+        numy : INT
+            Number of markers in y-direction in initial grid configuration.
+
+        Returns
+        -------
+        None.
+
+        '''
         
         # number of markers in each direction in initial setup
         self.xnum = numx
@@ -161,9 +135,49 @@ spec_mat = [
 ]
 @jitclass(spec_mat)       
 class Materials():
+    '''
+    Class which stores the contents of material_properties.txt file
+
+    Attributes
+    ----------
+    num_materials : INT
+        number of materials listed in material_properties.txt
+    rho : ARRAY
+        Density parameters for each material: density, thermal expansion, compressibility
+    visc : ARRAY
+        Viscosity parameters fro each material:
+        model choice, cons visc, Ad, n, Ea, Va
+    mu : ARRAY
+        Shear modulus for each material.
+    plast : ARRAY
+        Plasticity parameters for each material:
+        C0, C1, sin(FI0), sin(FI1), gamma0, gamma1
+    Cp : ARRAY
+        Specific heat capacity for each material.
+    kT : ARRAY
+        Thermal conductivity parameters for each material:
+        k0, a
+    radH : ARRAY
+        Radiogenic heat production for each material.
+    
+    '''
     
     # creates and fills material properties from specified file
     def __init__(self, materialData):
+        '''
+        Constructor for the Materials class.
+
+        Parameters
+        ----------
+        materialData : ARRAY
+            Contents of the material_properties.txt file, loaded into a np array
+            using np.loadtxt.
+
+        Returns
+        -------
+        None.
+
+        '''
         
         # load the material parameters from a file
         #materialData = np.loadtxt(filename, skiprows=3, delimiter=",")
@@ -255,6 +269,87 @@ spec_grid = [
 
 @jitclass(spec_grid)
 class Grid():
+    '''
+    Class which contains all the grid quantities.
+    
+    Attributes
+    ----------
+    xnum : INT
+        Number of nodes in x-direction.
+    ynum : INT
+        Number of nodes in y-direction.
+    x : ARRAY
+        x-diection positions of basic nodes
+    y : ARRAY
+        y-direction positions of basic nodes.
+    xstp : ARRAY
+        x-direction spacing between basic nodes.
+    ystp : ARRAY
+        y-direction spacing between basic nodes.
+    rho : ARRAY
+        Density.
+    rhoCp : ARRAY
+        density * heat capacity, for use in Temperature solver
+    T : ARRAY
+        Temperature
+    kT : ARRAY
+        Thermal conductivity
+    H_a : ARRAY
+        Adiabatic heat
+    H_r : ARRAY
+        Radiogenic heat
+    wt : ARRAY
+        weights for markers to grid interpolation of basic properties
+    eta_s : ARRAY
+        Viscosity for shear stress calculation.
+    wt_eta_s : ARRAY
+        weights for markers to interpolation of shear stress quantities
+    sigxy : ARRAY
+        Shear stresses
+    mu_s : ARRAY
+        shear modulus for shear stresses
+    epsxy : ARRAY
+        shear strain rate
+    sigxy2 : ARRAY
+        Updated shear stress (after Stoke's solve).
+    dsigxy : ARRAY
+        shear stress difference, for subgrid stress difference.
+    espin : ARRAY
+        spin tensor (for rotation of stress components).
+    P : ARRAY
+        Pressure
+    eta_n : ARRAY
+        Viscosity for normal stress calculations.
+    wt_eta_n : ARRAY
+        Weights for markers to interpolation of normal stress quantities
+    sigxx : ARRAY
+        Normal stresses
+    mu_n : ARRAY
+        shear modulus for normal stresses
+    epsxx : ARRAY
+        Normal strain rate
+    sigxx2 : ARRAY
+        Updated normal stress (after Stoke's solve).
+    dsigxx : ARRAY
+        Normal stress difference, for subgrid stress difference.
+    espii : ARRAY
+        Deviatoric strain rate.
+    vx : ARRAY
+        x-direction velocities
+    vy : ARRAY
+        y-direction velocities
+    cx : ARRAY
+        cell-centered node x-positions
+    cy : ARRAY
+        cell-centered node y-positions
+    xstpc : ARRAY
+        centered node x spacings
+    ystpc : ARRAY
+        centered node y spacings
+        
+    
+    '''
+    
     
     # creates empty grid structures
     def __init__(self, xnum, ynum):

--- a/dataStructures.py
+++ b/dataStructures.py
@@ -180,6 +180,7 @@ class Materials():
         # viscosity model parameters
         # 0 - choice of viscosity model (0 = constant visc, 1 = power law)
         # 1 - viscosity for constant model
+        # power law visc, eta = Ad * sigma**n * exp(-(Ea + Va*P)/RT)
         # 2 - Ad
         # 3 - n
         # 4 - Ea
@@ -190,12 +191,15 @@ class Materials():
         self.mu = materialData[:,9] 
         
         # plasticity parameters
-        # 0 - C0
-        # 1 - C1
-        # 2 - sin(FI0)
-        # 3 - sin(FI1)
-        # 4 - Gamma0
-        # 5 - Gamma1
+        # for details see eqns 14.10-12 in Gerya
+        
+        # 0 - C0 - cohesion, pre strain weakening
+        # 1 - C1 - cohesion, post strain weakening
+        # 2 - sin(FI0) - internal friction, pre-stain weakening 
+        # 3 - sin(FI1) - internal friction, post-strain weakening
+        # 4 - Gamma0 - for sig_ii < Gamma0, cohesion and friction = C0, sin(F0)
+        # 	       for gamma0 < sigii < gamma1, coh, frict given by eqn 14.10
+        # 5 - Gamma1 - for sigii > Gamma1, cohesion and friction = C0, sin(F0)
         self.plast = materialData[:,10:16]
         
         # Specific heat capacity

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/_templates/custom_class.rst
+++ b/docs/source/_templates/custom_class.rst
@@ -1,0 +1,32 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/custom_module.rst
+++ b/docs/source/_templates/custom_module.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {%- if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block functions %}
+   {%- if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block classes %}
+   {%- if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom_class.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+   {%- block exceptions %}
+   {%- if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {%- endblock %}
+
+{%- block modules %}
+{%- if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: custom_module.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{%- endblock %}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,16 @@
+API
+===
+
+.. autosummary::
+   :toctree: generated
+   :template: custom_module.rst
+   :recursive:
+   
+   dataStructures
+   physics.markers_fns
+   physics.grid_fns
+   physics.markerUtils
+   physics.StokesContinuitySolver
+   physics.TemperatureSolver
+   visualisation
+   models.lithosphereExtension.setup

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Modelling Earth Systems'
+copyright = '2025, Charlotte Summers'
+author = 'Charlotte Summers'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+	'sphinx.ext.duration',
+	'sphinx.ext.doctest',
+	'sphinx.ext.autodoc',
+        'sphinx.ext.autosummary',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+autosummary_generate = True
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here.
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,14 @@
+Modelling Earth Systems - Project code documentation
+=====================================================
+
+A python reworking of the thermomechanical code developed in the book Numerical Geodynamic Modelling by Taras Gerya [1]_ . It uses a finite difference staggered grid approach to solve the Stoke's, continuity and temperature equations, along with markers for advection.
+
+.. [1] Gerya T. MATLAB program examples. In: Introduction to Numerical Geodynamic Modelling. Cambridge University Press; 2019:425-437. `DOI <https://doi.org/10.1017/9781316534243.024>`_
+
+.. toctree::
+   :maxdepth: 2
+   
+   setup
+   run
+   api
+

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -1,0 +1,18 @@
+Running your model
+==================
+
+To run a model, simply check that you have imported the ``initializeModel`` for your chosen simulation at the top of the ``main.py`` fil, then run the ``main.py`` script!
+
+jit compilation
+---------------
+The code uses just-in-time (jit) compilation from the numba package.  This compiles functions on their first usage, and then reuses this compiled code for all subsequent calls of that function, improving the performance of the code dramatically (you'll notice that the first timestep is much slower than the following ones as this includes all the compile time).  
+
+If you wish to disable jit e.g. for debugging, change the environment variable ``NUMBA_DISABLE_JIT`` to 1 (there is a line after the import statements in ``main.py`` that can be used for this) and comment out the ``@jitclass`` decorators on all the class definitions.  To switch it back on, you'll need to restart you python kernel.
+
+Visualisation
+-------------
+
+The ``visualisation.py`` file contains some basic functions for plotting.  To change what variables are plotted, simply change the grid variable in the plot command within these functions to your chosen variable.  :py:class:`dataStructures.Grid` shows the available grid variables for plotting.
+
+
+

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -1,0 +1,156 @@
+Setting up a model
+==================
+
+To set up a model, first create a new directory in the models directory, with a name that describes what your model will be.  This directory needs to contain a version of ``setup.py`` and a ``material_properties.txt``.  The ``setup.py`` file contains two functions:
+
+:py:func:`models.lithosphereExtension.setup.initializeModel`
+
+which is used to set boundary conditions and required parameters for a simulation, and
+
+:py:func:`models.lithosphereExtension.setup.initialize_markers`
+
+which is called by ``initializeModel`` and creates and distributes the markers across the simulation domain.  This function is where the initial material properties and temperatures are defined, based on a marker's position.  This ``initializeModel`` instance should be imported by changing the import path in the ``main.py`` script to match the directory path of you newly created model. 
+
+.. note:: The easiest way to create a new setup is to copy an existing one and edit it! 
+
+There should also be a copy of the Parameters object in ```setup.py```.  This defines all the numerical and physical parameters required for your simulation, there is a base set of parameters that are required for any simulation, which are shown in the example implementation.  You can also add further parameters, by copying the Parameters definition to your setup.py and adding extra attributes, remembering to also add their types to the spec_par list.
+  
+.. note:: This cannot be done by creating a class that inherits from the example as ```jitclass``` does not support inheritance.
+
+Material Properties
+-------------------
+This text file should contain the required properties for each different material in your model.  Each row should contain the following values in the order they are listed in the table:
+
++------------------------+-----------------------------------------+-----------+
+| Parameter              | Description                             | Optional? |
++========================+=========================================+===========+
+| density, :math:`\rho`  | basic density of the material           | no        |
++------------------------+-----------------------------------------+-----------+
+| thermal expansion      | gives change in density due to thermal  | yes       |
+| coefficient :math:`c_T`| expansion as: :math:`\rho (1 - c_T T)`  |           |
++------------------------+-----------------------------------------+-----------+
+| Compressibility        | gives change in density due to pressure | yes       |
+| coefficient :math:`c_P`| as :math:`\rho (1 + c_P P)`             |           |
++------------------------+-----------------------------------------+-----------+
+| Viscosity model        | flag which specifies the viscosity      | no        |
+| choice                 | model used:                             |           |
+|                        | 0 = constant, 1 = power law             |           |
++------------------------+-----------------------------------------+-----------+
+| Constant viscosity     | If a constant viscosity is chosen, this | depends   |
+|                        | contains the value of that viscosity    | on flag   |
++------------------------+-----------------------------------------+-----------+
+| Power law viscosity,   | The material constant for the           | depends   |
+| :math:`A_d` parameter  | power law viscosity model               | on flag   |
+|                        | :math:`A_d\sigma^n exp(-(E_a+V_a P)/RT)`|           |
++------------------------+-----------------------------------------+-----------+
+| Power law viscosity,   | The stress exponent for the             | depends   |
+| :math:`n` parameter    | power law viscosity model               | on flag   |
+|                        | :math:`A_d\sigma^n exp(-(E_a+V_a P)/RT)`|           |
++------------------------+-----------------------------------------+-----------+
+| Power law viscosity,   | Experimentally determined rheological   | depends   |
+| :math:`E_a` parameter  | parameter for power law viscosity model | on flag   |
+|                        | :math:`A_d\sigma^n exp(-(E_a+V_a P)/RT)`|           |
++------------------------+-----------------------------------------+-----------+
+| Power law viscosity,   | Experimentally determined rheological   | depends   |
+| :math:`V_a` parameter  | parameter for power law viscosity model | on flag   |
+|                        | :math:`A_d\sigma^n exp(-(E_a+V_a P)/RT)`|           |
++------------------------+-----------------------------------------+-----------+
+| Shear modulus          | The shear modulus of the material       | no        |
++------------------------+-----------------------------------------+-----------+
+| Plasticity, cohesion   | The cohesion used when the strain is    | yes       |
+| pre strain weakening   | below the lower strain threshold        |           |
+| :math:`C_0`            | :math:`\gamma_0`                        |           |
++------------------------+-----------------------------------------+-----------+
+| Plasticity, cohesion   | The cohesion used when the strain is    | yes       |
+| post strain weakening  | above the upper strain threshold        |           |
+| :math:`C_1`            | :math:`\gamma_1`                        |           |
++------------------------+-----------------------------------------+-----------+
+| Plasticity, internal   | The internal friction used when the     | yes       |
+| friction pre strain    | strain is below the lower strain        |           |
+| weakening              | threshold  :math:`\gamma_0`             |           |
++------------------------+-----------------------------------------+-----------+
+| Plasticity, internal   | The internal friction used when the     | yes       |
+| friction post strain   | strain is above the upper strain        |           |
+| weakening              | threshold  :math:`\gamma_1`             |           |
++------------------------+-----------------------------------------+-----------+
+| Plasticity, lower      | The strain threshold below which no     | yes       |
+| strain threshold,      | strain weaking is applied               |           |
+| :math:`\gamma_0`       |                                         |           |
++------------------------+-----------------------------------------+-----------+
+| Plasticity, upper      | The strain threshold above which full   | yes       |
+| strain threshold,      | strain weaking is applied, in between   |           |
+| :math:`\gamma_1`       | a combination of the parameters is used |           |
++------------------------+-----------------------------------------+-----------+
+| Specific heat capacity | The specific heat capacity at constant  | no        |
+| :math:`C_p`            | pressure                                |           |
++------------------------+-----------------------------------------+-----------+
+| Thermal conductivity   | The constant thermal conductivity       | no        |
+| :math:`k_T`            |                                         |           |
++------------------------+-----------------------------------------+-----------+
+| Thermal conductivity   | The coefficient of temperature          | yes       |
+| temperature coefficient| dependence for the thermal conductivity |           |
+| :math:`a`              | :math:`k_T + a/(T+77)`                  |           |
++------------------------+-----------------------------------------+-----------+
+| Radiogenic heating     | Heat production from radiogenic sources | yes       |
+| term (W/m**3)          |                                         |           |
++------------------------+-----------------------------------------+-----------+
+
+for values which are optional, 0 should be entered if they are not required/ in use.  This must be done consistently, for example, all of the plasticity parameters should be zeroed if plasticity is not in use.
+
+
+Boundary Conditions
+-------------------
+
+Velocity
+^^^^^^^^
+
+The boundary conditions applied at each wall for velocities are specified in 4 arrays: ``B_top``, ``B_bottom``, ``B_left`` and ``B_right``, where top/bottom refers to the y-direction and left/right the x.  Each contain 4 columns with xnum/ynum elements for the top and bottom / left and right arrays repectively.  The first two columns are the :math:`v_x` conditions and the second two are the :math:`v_y` conditions.  The values in the columns set the values for the i/jth (for the x/y directions respectively) 'ghost node' velocities as:
+
+``vx[0,j] = B_bottom[j,0] + vx[1,j]*B_bottom[j,1]``
+
+and for the :math:`v_y` condition,
+
+``vy[0,j] = B_bottom[j,2] + vy[1,j]*B_bottom[j,3]``
+
+The table below shows how to implement several common boundary conditions in this structure, note that the single row shown is representing the same pattern in all rows of the array:
+
++------------------------+----------------------------------------------+
+| Boundary condition     | Array structure (showing a single row)       |
++========================+==============================================+
+| No slip                | ``[0, 0, 0, 0]``                             |
++------------------------+----------------------------------------------+
+| Free slip              | ``[0, 1, 0, 0]`` for top / bottom,           |
+|                        | ``[0, 0, 0, 1]`` for left / right            |
++------------------------+----------------------------------------------+
+| Grid deformation       | ``[0, 1, -v/xsize*ysize, 0]`` for top/bottom |
+| spreading in x         | ``[(-/+)v/2, 0, 0, 1]`` for left/right       |
++------------------------+----------------------------------------------+
+| Prescribed inflow      | ``[v, 0, 0, 0]`` for top / bottom,           |
+| parallel to boundary   | ``[0, 0, v, 0]`` for left / right            |
++------------------------+----------------------------------------------+
+
+Temperature
+^^^^^^^^^^^
+
+A similar structure is used for the temperature boundary conditions.  These are again specified in 4 arrays: ``BT_top``,``BT_bottom``, ``BT_left`` and ``BT_right``.  Each array contains two columns that are used to calculate the ghost node temperature as:
+``T[0,j] = BT_top[0] + BT_top[1]*T[1,j]``
+
+Some common boundary condition types can be formulated in this structure as:
+
++------------------------+------------------------+
+| Boundary condition     | Array structure        |
+|                        | (showing a single row) |
++========================+========================+
+| Insulating             | ``[0, 1]``             |
++------------------------+------------------------+
+| Prescribed temperature | ``[T, 0]``             |
++------------------------+------------------------+
+
+
+Initial Conditions
+------------------
+The initial conditions for the simulation are set by applying material IDs and temperatures to the markers in :py:func:`models.lithosphereExtension.setup.initialize_markers`.
+
+Within this function, the markers are distributed evenly across the domain with a small random displacement.  The user can then assign them a material type/ID and a temperature based on their position.  For example, in the lithosphere extension model, the different materials are assigned using depth, to give the layers of the crust and upper mantle.
+
+

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -146,6 +146,36 @@ Some common boundary condition types can be formulated in this structure as:
 | Prescribed temperature | ``[T, 0]``             |
 +------------------------+------------------------+
 
+Internal velocity Boundary
+--------------------------
+There is also an option to include a 'mobile wall', which is a vertical wall within the simulation domain on which a :math:`x` and/or :math:`y` velocity can be fixed.  The :math:`x` and :math:`y` velocities can be fixed on the same or separate vertical lines.  This is implemented using the ``B_intern`` array, which has the following format:
+
++-------+-------------------------------+------------+
+| index | description                   | value when | 
+|       |                               | not in use |
++=======+===============================+============+
+| 0     | x index of the wall on        | -1         |
+|       | which the x velocity is fixed |            | 
++-------+-------------------------------+------------+
+| 1     | min y-index of the wall       | 0          |
++-------+-------------------------------+------------+
+| 2     | max y-index of the wall       | 0          |
++-------+-------------------------------+------------+
+| 3     | x-velocity on the wall        | 0          |
+|       | described by elements 0-2     |            |
++-------+-------------------------------+------------+
+| 4     | x index of the wall on        | -1         |
+|       | which the y velocity is fixed |            | 
++-------+-------------------------------+------------+
+| 5     | min y-index of the wall       | 0          |
++-------+-------------------------------+------------+
+| 6     | max y-index of the wall       | 0          |
++-------+-------------------------------+------------+
+| 7     | y-velocity on the wall        | 0          |
+|       | described by elements 4-6     |            | 
++-------+-------------------------------+------------+ 
+
+A simple example which shows the effect of this internal wall is in ``models/internalVelocityExample``.
 
 Initial Conditions
 ------------------

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ os.environ["NUMBA_DISABLE_JIT"] = "0"
 debug = 0
 
 # load the component fucntions from their respective files
-from dataStructures import Markers, Materials, Grid, Parameters, copyGrid
+from dataStructures import Markers, Materials, Grid, copyGrid
 
 from physics.StokesContinuitySolver import StokesContinuitySolver, constructStokesRHS
 from physics.TemperatureSolver import TemperatureSolver, constructTempRHS
@@ -31,7 +31,7 @@ from physics.grid_fns import updateStresses, viscElastStress, strainRateComps, g
 from visualisation import plotAVar, plotSeveralVars, plotMarkerFields, basicGridVelocities
 
 # load the setup fn for the chosen model
-from models.lithosphereExtension.setup import initializeModel
+from models.lithosphereExtension.setup import initializeModel, Parameters
 
 
 

--- a/models/internalVelocityExample/material_properties_simple.txt
+++ b/models/internalVelocityExample/material_properties_simple.txt
@@ -1,0 +1,6 @@
+# material properties for simulation
+# left, right
+# standard density, thermal expansion, compressibility, viscosity model (0=const visc, 1=power law), viscosity (if constant), AD, n, Ea, Va, shear modulus, C0m C1, sin(FI0), sin(FI1), Gamma0, Gamma1, C_P, k0, a, Radiogenic heat production
+3300, 0, 0, 0, 1e22, 0, 0, 0, 0, 6.7e5, 0, 0, 0, 0, 0, 0, 1000, 3, 0, 0
+3300, 0, 0, 0, 1e20, 0, 0, 0, 0, 6.7e5, 0, 0, 0, 0, 0, 0, 1000, 3, 0, 0
+

--- a/models/internalVelocityExample/setup.py
+++ b/models/internalVelocityExample/setup.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Simple square of higher viscosity with internal boundary wall to cause it to move.
+A demonstration of the 'moving wall' internal boundary conditions.
+"""
+import numpy as np
+
+from dataStructures import Markers, Grid, Materials
+from physics.grid_fns import gridSpacings
+import pathlib
+from numba import jit, float64, int64
+from numba.experimental import jitclass
+
+
+def initializeModel():
+    '''
+    Sets up the initial state of the model, including BCs and output settings.
+
+    Returns
+    -------
+    params : Parameters object
+        Model physical and numerical parameters.
+    grid : Grid object
+        Initialised Grid object.
+    materials : Materials
+        Materials object initialsed with required material properties.
+    markers : Markers
+        Initialized markers object.
+    xsize : INT
+        x-resolution of model domain.
+    ysize : INT
+        y-resolution of model domain.
+    P_first : ARRAY
+        Array with 2 entries, specifying pressure BC.
+    B_top : ARRAY
+        Boundary conditions at the top of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,j] = B_top[j,0] + vx[1,j]*B_top[j,1]
+        vy[0,j] = B_top[j,2] + vy[1,j]*B_top[j,3]
+    B_bottom : ARRAY
+        Boundary conditions at the bottom of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,j] = B_bot[j,0] + vx[1,j]*B_bot[j,1]
+        vy[0,j] = B_bot[j,2] + vy[1,j]*B_bot[j,3]
+    B_left : ARRAY
+        Boundary conditions at the left of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,i] = B_left[i,0] + vx[1,i]*B_left[i,1]
+        vy[0,i] = B_left[j,2] + vy[1,i]*B_left[i,3]
+    B_right : ARRAY
+        Boundary conditions at the left of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,i] = B_right[i,0] + vx[1,i]*B_right[i,1]
+        vy[0,i] = B_right[j,2] + vy[1,i]*B_right[i,3]
+    B_intern : ARRAY
+        Array defining optional internal boundary eg. moving wall. Format is:
+        B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
+        B_intern[1-2] = min/max y-index of the wall
+        B_intern[3] = prescribed x-velocity value.
+        B_intern[4] = x-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[5-6] = min/max y-index of the wall
+        B_intern[7] = prescribed y-velocity value.
+    BT_top : ARRAY
+        Top temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_top[0] + BT_top[1]*T[i+1,j]
+    BT_bottom : ARRAY
+        Bottom temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_bottom[0] + BT_bottom[1]*T[i-1,j]
+    BT_left : ARRAY
+        Left temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_left[0] + BT_left[1]*T[i,j+1]
+    BT_right : ARRAY
+        Right temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_right[0] + BT_right[1]*T[i,j-1]
+
+    '''
+    
+    # instantiate a pre-populated parameters object
+    params = Parameters()
+    
+    params.v_ext = 0.0
+    
+
+    # additional model options 
+    # initial system size
+    xsize0 = 1e5
+    ysize0 = 1.5e5
+    
+    xsize = xsize0
+    ysize = ysize0
+
+    # set resolution
+    xnum = 31
+    ynum = 21
+    
+    params.bx = xsize/(xnum-1)
+    params.by = ysize/(ynum-1)
+    params.Nx = 0
+    params.Ny = 0
+    params.non_uni_xsize = 0
+
+
+    # instantiate/load material properties object
+    matData = np.loadtxt('./models/internalVelocityTest/material_properties_simple.txt', delimiter=",")
+    materials = Materials(matData) 
+
+    params.save_fig = 1
+    params.ntstp_max = 10
+
+    # create directories for output of figures and data (not atm)
+    pathlib.Path('./Figures').mkdir(exist_ok=True)
+    pathlib.Path('./Output').mkdir(exist_ok=True)
+
+    ###########################################################################    
+    # Boundary conditions
+    # pressure BCs
+    P_first = np.array([0,1e5])
+
+    # velocity BCs, free slip
+    B_top = np.zeros([xnum+1,4])
+    B_top[:,1] = 1
+
+    B_bottom = np.zeros([xnum+1,4])
+    B_bottom[:,1] = 1
+
+    B_left = np.zeros([ynum+1,4])
+    B_left[:,3] = 1
+
+    B_right = np.zeros([ynum+1,4])
+    B_right[:,3] = 1
+
+    # optional internal boundary, create a fixed velocity wall, to test the conditions
+    B_intern = np.zeros([8])
+    # for a x-direction
+    B_intern[4] = -1
+    B_intern[0] = 13
+    B_intern[1] = 7
+    B_intern[2] = 13
+    B_intern[3] = 1e-6
+    
+    # for a y-direction
+    #B_intern[0] = -1
+    #B_intern[4] = 15
+    #B_intern[5] = 7
+    #B_intern[6] = 13
+    #B_intern[7] = 1e-6
+    
+    
+    # temperature BCs
+    BT_top = np.zeros([xnum, 2])
+    BT_bottom = np.zeros([xnum, 2])
+    BT_left = np.zeros([ynum, 2])
+    BT_right = np.zeros([ynum, 2])
+
+    # upper and lower  - symmetry
+    BT_top[:,1] = 1
+    BT_bottom[:,1] = 1
+
+    # left and right = symmetry/insulating? = -1?
+    BT_left[:,1] = 1
+    BT_right[:,1] = 1
+
+    ###########################################################################
+    # create grid object
+    grid = Grid(xnum, ynum)
+    
+
+    # define grid points for (potentially) unevenly spaced grid
+    gridSpacings(params.bx, params.by, params.Nx, params.Ny, params.non_uni_xsize, xsize, ysize, grid, 0)
+
+    ############################################################################
+    # create markers object
+    mnumx = 400
+    mnumy = 300
+    markers = Markers(mnumx, mnumy)
+
+    # initialize markers
+    initialize_markers(markers, materials, params, xsize, ysize)
+    
+    return params, grid, materials, markers, xsize, ysize, P_first, B_top, B_bottom,\
+           B_left, B_right, B_intern, BT_top, BT_bottom, BT_left, BT_right
+           
+           
+
+def initialize_markers(markers, materials, params, xsize, ysize):
+    '''
+    Initialize the positions, material ID and temperature of the markers.
+    
+    Parameters
+    ----------
+    markers : Markers Object
+        An empty markers object, which will be filled by this function.
+        materials : Materials object
+        Materials object filled from file with the required materials.
+    params : Parameters Object
+        Contains the simulation parameters
+    xsize : FLOAT
+        Physical x-size of the simulation domain.
+    ysize : FLOAT
+        Physical y-size of the simulation domain.
+
+    Returns
+    -------
+    None.
+
+    '''
+    
+    # set the rough grid spacing for the markers
+    mxstp = xsize/markers.xnum
+    mystp = ysize/markers.ynum
+    
+    # marker number index
+    mm = 0
+    
+    for j in range(0,markers.xnum):
+        for i in range(0,markers.ynum):
+            
+            # set coordinates as grid + small random displacement
+            markers.x[mm] = (j + np.random.random())*mxstp
+            markers.y[mm] = (i + np.random.random())*mystp
+            
+            # now define rock type based on location, to give our initial setup
+            # inside the intrusion
+            if (markers.y[mm] > ysize*0.4 and markers.y[mm] < ysize*0.6 and markers.x[mm] > xsize*0.4 and markers.x[mm] < xsize*0.6):
+                markers.id[mm] = 0
+                markers.T[mm] = 1000
+            else:
+                markers.id[mm] = 1
+                markers.T[mm] = 1000
+                
+            
+            # update marker index
+            mm +=1
+            
+spec_par = [
+    ('gx', float64),
+    ('gy', float64),
+    ('Rgas', float64),
+    ('T_min', float64),
+    ('v_ext', float64),
+    ('eta_min', float64),
+    ('eta_max', float64),
+    ('stress_min', float64),
+    ('eta_wt', float64),
+    ('max_pow_law', float64),
+    ('t_end', float64),
+    ('ntstp_max', int64),
+    ('Temp_stp_max', int64),
+    ('tstp_max', float64),
+    ('marker_max', float64),
+    ('marker_sch', int64),
+    ('movemode', int64),
+    ('dsubgrid', float64),
+    ('dsubgridT', float64),
+    ('frict_yn', float64),
+    ('adia_yn', float64),
+    ('bx', float64),
+    ('by', float64),
+    ('Nx', int64),
+    ('Ny', int64),
+    ('non_uni_xsize', float64),
+    ('save_output', int64),
+    ('save_fig', int64),
+]
+@jitclass(spec_par)
+class Parameters():
+    '''
+    Class which holds the values of various physical and numerical parameters
+    required in the simulation.
+    
+    Attributes
+    ----------
+    gx : FLOAT
+        x-direction component of gravitational acceleration.
+    gy : FLOAT
+        y-direction component of gravitational acceleration.
+    Rgas : FLOAT
+        Ideal gas constant.
+    T_min : FLOAT
+        Minimum allowed temperature.
+    v_ext : FLOAT
+        Grid extension velocity, for deforming grid.
+    eta_min : FLOAT
+        Minimum allowed viscosity.
+    eta_max : FLOAT
+        Maximum allowed viscosity.
+    eta_wt : FLOAT
+        Weighting value for a (potentially not in use) visco-plastic model.
+    max_pow_law : FLOAT
+        Maximum allowed exponent in the power law viscosity model.
+    t_end : FLOAT
+        Time at which to end the simulation (if number of tsteps is less than ntstp_max).
+    ntstp_max : INT
+        Maximum number of timesteps to take.
+    Temp_stp_max : INT
+        Maximum number of temperature sub-timesteps to take.
+    tstp_max : FLOAT
+        Maximum size of timestep.
+    marker_max : FLOAT
+        Maximum fraction of average grid cell that a marker can move per timestep.
+    marker_sch : INT
+        Choice of advection scheme for markers, 1 = Euler, 4 = RK4
+    movemode : INT
+        Choice of how velocities are calculated, 0 = Stokes, no others implemented at present.
+    dsubgrid : FLOAT
+        Subgrid stress coefficient.
+    dsubgridT : FLOAT
+        Subgrid temperature diffusion coefficient.
+    frict_yn : FLOAT
+        Flag to apply friction heating.
+    adia_yn : FLOAT
+        Flag to apply adiabatic heating.
+    bx: FLOAT
+        x-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be xsize/(xnum-1).
+    by: FLOAT
+        y-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be ysize/(ynum-1).
+    Nx: INT
+        Number of uneven grid cells either side of the central high resolution 
+        region in the x-direction, for uniform grid this should be 0.
+    Ny: INT
+        Number of uneven grid cells below the high resolution 
+        region in the y-direction, for uniform grid this should be 0.
+    non_uni_size: FLOAT
+        Physical size of the non-uniform grid region in the x-direction.  For 
+        uniform grid this should be 0.
+    save_output : INT
+        Number of steps between output, not currently implemented.
+    save_fig : INT
+        Number of steps between plotting of figures.
+    
+    
+    '''
+    
+    
+    # creates parameters object
+    def __init__(self):
+        '''
+        Constructor for the parameters class
+        
+        Sets the default (lithsphere extension) values for all params
+
+        Returns
+        -------
+        None.
+
+        '''
+        # main parameters, required by all simulations
+        
+        # physical constants
+        self.gx = 0.0                           # x-direction gravitational acc
+        self.gy = 9.81                          # y-direction gravitational acc
+        self.Rgas = 8.314                       # gas constant
+        
+        # physical model setup
+        self.T_min = 273                        # temperature at the top face of the model (K)
+        
+        self.v_ext = 2.0/(100*365.25*24*3600)   # extension velocity of the grid (cm/yr)
+        
+        # viscosity model
+        self.eta_min = 1e18                     # minimum viscosity
+        self.eta_max = 1e25                     # maximum viscosity
+        self.stress_min = 1e4                   # minimum stress
+        self.eta_wt = 0                         # viscosity weighting, for (old?) visco-plastic model
+        self.max_pow_law = 150                  # maximum power law exponent in visc model
+        
+        
+        # timestepping
+        self.t_end = 72e3/self.v_ext            # end time
+        self.ntstp_max = 360                    # maximum number of timesteps
+        self.Temp_stp_max = 20                  # maximum number of temperature substeps
+        
+        self.tstp_max = 1e4*365.25*24*3600      # maximum timestep
+        
+        # marker options
+        self.marker_max = 0.3                   # maximum marker movement per timestep (fraction of av. grid step)
+        self.marker_sch = 4                     # marker scheme 0 = no movement, 1 = Euler, 4=RK4
+        
+        self.movemode = 0                       # velocity calculation 0 = momentum eqn, 1 = solid body (not working currently)
+        
+        # subgrid diffusion
+        self.dsubgrid = 1                       # subgrid stress coeff (none if zero)
+        self.dsubgridT = 1                      # subgrid diffusion coeff(none if zero)
+        
+        # switches for heating terms
+        self.frict_yn = 1                       # use friction heating?
+        self.adia_yn = 1                        # use adiabatic heating?
+        
+        # grid spacing params
+        self.bx = 2000                          # x-grid spacing in high res area
+        self.by = 2000                          # y-grid spacing in high res area
+        self.Nx = 30                            # number of unevenly spaced grid points either side of high res zone
+        self.Ny = 20                            # number of unvenly spaced grid points below high res zone
+        self.non_uni_xsize = 100000             # physical x-size of non-uniform grid region
+        
+        # output options
+        self.save_output = 50                        # number of steps between output files
+        self.save_fig = 20                            # number of steps between figure output

--- a/models/lithosphereExtension/material_properties.txt
+++ b/models/lithosphereExtension/material_properties.txt
@@ -1,6 +1,7 @@
 # material properties for simulation
 # materials, in row order: sticky air, sediments, upper oceanic crust (basalts), lower oceanic crust (gabbro), lithospheric mantle, asthenospheric mantle, hydrated mantle, upper continental crust, upper continental crust (for visualisation), lower continental crust, lower continental crust (for visualisation) 
-# standard density, thermal expansion, compressibility, viscosity model (0=const visc, 1=power law), viscosity (if constant), AD, n, Ea, Va, shear modulus, C0m C1, sin(FI0), sin(FI1), Gamma0, Gamma1, C_P, k0, a, Radiogenic heat production
+# content of each row, see definition of Materials object in dataStructures for details on parameters:
+# standard density, thermal expansion, compressibility, viscosity model flag (0=const visc, 1=power law), viscosity (if constant), AD, n, Ea, Va, shear modulus, C0m C1, sin(FI0), sin(FI1), Gamma0, Gamma1, C_P, k0, a, Radiogenic heat production
 1000, 3e-5, 1e-11, 0, 1e18, 0, 0, 0, 0, 1e20, 0, 0, 0, 0, 0, 1, 3000, 300, 0, 0
 2700, 3e-5, 1e-11, 1, 0, 3.2e-4, 2.3, 154.0e3, 0,     1.0e10, 1e6, 1e6, 0.1, 0.1, 0, 1, 1000, 0.64, 807, 2e-6
 3000, 3e-5, 1e-11, 1, 0, 3.2e-4, 2.3, 154.0e3, 0,     2.5e10, 1e6, 1e6, 0.1, 0.1, 0, 1, 1000, 1.18, 474, 2.5e-7

--- a/models/lithosphereExtension/setup.py
+++ b/models/lithosphereExtension/setup.py
@@ -163,10 +163,10 @@ def initializeModel():
         Array defining optional internal boundary eg. moving wall. Format is:
         B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
         B_intern[1-2] = min/max y-index of the wall
-        B_intern[4] = prescribed x-velocity value.
-        B_intern[5] = y-index of vy nodes with prescribed velocity (-1 is not in use)
-        B_intern[6-7] = min/max x-index of the wall
-        B_intern[8] = prescribed y-velocity value.
+        B_intern[3] = prescribed x-velocity value.
+        B_intern[4] = x-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[5-6] = min/max y-index of the wall
+        B_intern[7] = prescribed y-velocity value.
     BT_top : ARRAY
         Top temperature BCs.  Array has 2 columns, values in each are defined as:
         T[i,j] = BT_top[0] + BT_top[1]*T[i+1,j]

--- a/models/lithosphereExtension/setup.py
+++ b/models/lithosphereExtension/setup.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-File which contains the setup for a lithospheric extension model
+Setup for a lithospheric extension model, the default setup for the original code.
 
 """
 
 import numpy as np
 import pathlib
+from numba import jit, float64, int64
+from numba.experimental import jitclass
 
-from dataStructures import Markers, Parameters, Grid, Materials
+from dataStructures import Markers, Grid, Materials
 from physics.grid_fns import gridSpacings
+
 
 
 def initialize_markers(markers, materials, params, xsize, ysize):
@@ -180,7 +183,7 @@ def initializeModel():
     '''
     
     
-    # instantiate a pre-populated parameters object
+    # instantiate a pre-populated parameters object, using the derived class
     params = Parameters()
 
     # additional model options 
@@ -241,7 +244,7 @@ def initializeModel():
     BT_top[:,0] = params.T_top
     BT_bottom[:,0] = params.T_bot
 
-    # left and right = insulating?
+    # left and right = insulating
     BT_left[:,1] = 1
     BT_right[:,1] = 1
 
@@ -265,10 +268,184 @@ def initializeModel():
            B_left, B_right, B_intern, BT_top, BT_bottom, BT_left, BT_right
     
     
+
+spec_par = [
+    ('gx', float64),
+    ('gy', float64),
+    ('Rgas', float64),
+    ('T_min', float64),
+    ('v_ext', float64),
+    ('eta_min', float64),
+    ('eta_max', float64),
+    ('stress_min', float64),
+    ('eta_wt', float64),
+    ('max_pow_law', float64),
+    ('t_end', float64),
+    ('ntstp_max', int64),
+    ('Temp_stp_max', int64),
+    ('tstp_max', float64),
+    ('marker_max', float64),
+    ('marker_sch', int64),
+    ('movemode', int64),
+    ('dsubgrid', float64),
+    ('dsubgridT', float64),
+    ('frict_yn', float64),
+    ('adia_yn', float64),
+    ('bx', float64),
+    ('by', float64),
+    ('Nx', int64),
+    ('Ny', int64),
+    ('non_uni_xsize', float64),
+    ('save_output', int64),
+    ('save_fig', int64),
+    ('T_top', float64),
+    ('T_bot', float64),
+]
+@jitclass(spec_par)
+class Parameters():
+    '''
+    Class which holds the values of various physical and numerical parameters
+    required in the simulation.
     
+    Attributes
+    ----------
+    gx : FLOAT
+        x-direction component of gravitational acceleration.
+    gy : FLOAT
+        y-direction component of gravitational acceleration.
+    Rgas : FLOAT
+        Ideal gas constant.
+    T_min : FLOAT
+        Minimum allowed temperature.
+    v_ext : FLOAT
+        Grid extension velocity, for deforming grid.
+    eta_min : FLOAT
+        Minimum allowed viscosity.
+    eta_max : FLOAT
+        Maximum allowed viscosity.
+    eta_wt : FLOAT
+        Weighting value for a (potentially not in use) visco-plastic model.
+    max_pow_law : FLOAT
+        Maximum allowed exponent in the power law viscosity model.
+    t_end : FLOAT
+        Time at which to end the simulation (if number of tsteps is less than ntstp_max).
+    ntstp_max : INT
+        Maximum number of timesteps to take.
+    Temp_stp_max : INT
+        Maximum number of temperature sub-timesteps to take.
+    tstp_max : FLOAT
+        Maximum size of timestep.
+    marker_max : FLOAT
+        Maximum fraction of average grid cell that a marker can move per timestep.
+    marker_sch : INT
+        Choice of advection scheme for markers, 1 = Euler, 4 = RK4
+    movemode : INT
+        Choice of how velocities are calculated, 0 = Stokes, no others implemented at present.
+    dsubgrid : FLOAT
+        Subgrid stress coefficient.
+    dsubgridT : FLOAT
+        Subgrid temperature diffusion coefficient.
+    frict_yn : FLOAT
+        Flag to apply friction heating.
+    adia_yn : FLOAT
+        Flag to apply adiabatic heating.
+    bx: FLOAT
+        x-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be xsize/(xnum-1).
+    by: FLOAT
+        y-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be ysize/(ynum-1).
+    Nx: INT
+        Number of uneven grid cells either side of the central high resolution 
+        region in the x-direction, for uniform grid this should be 0.
+    Ny: INT
+        Number of uneven grid cells below the high resolution 
+        region in the y-direction, for uniform grid this should be 0.
+    non_uni_size: FLOAT
+        Physical size of the non-uniform grid region in the x-direction.  For 
+        uniform grid this should be 0.
+    save_output : INT
+        Number of steps between output, not currently implemented.
+    save_fig : INT
+        Number of steps between plotting of figures.
+    T_top : FLOAT
+        Temperature at the top of the simulation domain.
+    T_bot : FLOAT
+        Temperature at the bottom of the simulation domain.
+    
+    
+    '''
+    
+    
+    # creates parameters object
+    def __init__(self):
+        '''
+        Constructor for the parameters class
+        
+        Sets the default (lithsphere extension) values for all params
 
+        Returns
+        -------
+        None.
 
+        '''
+        # main parameters, required by all simulations
+        
+        # physical constants
+        self.gx = 0.0                           # x-direction gravitational acc
+        self.gy = 9.81                          # y-direction gravitational acc
+        self.Rgas = 8.314                       # gas constant
+        
+        # physical model setup
+        self.T_min = 273                        # temperature at the top face of the model (K)
+        
+        self.v_ext = 2.0/(100*365.25*24*3600)   # extension velocity of the grid (cm/yr)
+        
+        # viscosity model
+        self.eta_min = 1e18                     # minimum viscosity
+        self.eta_max = 1e25                     # maximum viscosity
+        self.stress_min = 1e4                   # minimum stress
+        self.eta_wt = 0                         # viscosity weighting, for (old?) visco-plastic model
+        self.max_pow_law = 150                  # maximum power law exponent in visc model
+        
+        
+        # timestepping
+        self.t_end = 72e3/self.v_ext            # end time
+        self.ntstp_max = 360                    # maximum number of timesteps
+        self.Temp_stp_max = 20                  # maximum number of temperature substeps
+        
+        self.tstp_max = 1e4*365.25*24*3600      # maximum timestep
+        
+        # marker options
+        self.marker_max = 0.3                   # maximum marker movement per timestep (fraction of av. grid step)
+        self.marker_sch = 4                     # marker scheme 0 = no movement, 1 = Euler, 4=RK4
+        
+        self.movemode = 0                       # velocity calculation 0 = momentum eqn, 1 = solid body (not working currently)
+        
+        # subgrid diffusion
+        self.dsubgrid = 1                       # subgrid stress coeff (none if zero)
+        self.dsubgridT = 1                      # subgrid diffusion coeff(none if zero)
+        
+        # switches for heating terms
+        self.frict_yn = 1                       # use friction heating?
+        self.adia_yn = 1                        # use adiabatic heating?
+        
+        # grid spacing params
+        self.bx = 2000                          # x-grid spacing in high res area
+        self.by = 2000                          # y-grid spacing in high res area
+        self.Nx = 30                            # number of unevenly spaced grid points either side of high res zone
+        self.Ny = 20                            # number of unvenly spaced grid points below high res zone
+        self.non_uni_xsize = 100000             # physical x-size of non-uniform grid region
+        
+        # output options
+        self.save_output = 50                        # number of steps between output files
+        self.save_fig = 20                            # number of steps between figure output
 
+        
+        ########################################################################
+        # params specific only to this setup
+        self.T_top = self.T_min                 # temperature at the top face of the model (K)
+        self.T_bot = 1750                       # temperature at the bottom face of the model (K)
 
 
 

--- a/models/lithosphereExtension/setup.py
+++ b/models/lithosphereExtension/setup.py
@@ -198,7 +198,7 @@ def initializeModel():
 
     # instantiate/load material properties object
     # file path must be from top directory (as that is where the fn is called from!)
-    matData = np.loadtxt('./models/lithosphereExtension/material_properties.txt', skiprows=3, delimiter=",")
+    matData = np.loadtxt('./models/lithosphereExtension/material_properties.txt', delimiter=",")
     materials = Materials(matData)
 
     # create directories for output of figures and data (not atm)

--- a/models/simpleStokesAndTempTest/setup.py
+++ b/models/simpleStokesAndTempTest/setup.py
@@ -10,9 +10,67 @@ from physics.grid_fns import gridSpacings
 import pathlib
 
 def initializeModel():
-    
-    # function which should contain everything required to set up a simulation
-    # so that we can easily swap out setups
+    '''
+    Sets up the initial state of the model, including BCs and output settings.
+
+    Returns
+    -------
+    params : Parameters object
+        Model physical and numerical parameters.
+    grid : Grid object
+        Initialised Grid object.
+    materials : Materials
+        Materials object initialsed with required material properties.
+    markers : Markers
+        Initialized markers object.
+    xsize : INT
+        x-resolution of model domain.
+    ysize : INT
+        y-resolution of model domain.
+    P_first : ARRAY
+        Array with 2 entries, specifying pressure BC.
+    B_top : ARRAY
+        Boundary conditions at the top of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,j] = B_top[j,0] + vx[1,j]*B_top[j,1]
+        vy[0,j] = B_top[j,2] + vy[1,j]*B_top[j,3]
+    B_bottom : ARRAY
+        Boundary conditions at the bottom of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,j] = B_bot[j,0] + vx[1,j]*B_bot[j,1]
+        vy[0,j] = B_bot[j,2] + vy[1,j]*B_bot[j,3]
+    B_left : ARRAY
+        Boundary conditions at the left of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,i] = B_left[i,0] + vx[1,i]*B_left[i,1]
+        vy[0,i] = B_left[j,2] + vy[1,i]*B_left[i,3]
+    B_right : ARRAY
+        Boundary conditions at the left of the grid. Array has 4 columns, 
+        values in each are defined as: 
+        vx[0,i] = B_right[i,0] + vx[1,i]*B_right[i,1]
+        vy[0,i] = B_right[j,2] + vy[1,i]*B_right[i,3]
+    B_intern : ARRAY
+        Array defining optional internal boundary eg. moving wall. Format is:
+        B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
+        B_intern[1-2] = min/max y-index of the wall
+        B_intern[4] = prescribed x-velocity value.
+        B_intern[5] = y-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[6-7] = min/max x-index of the wall
+        B_intern[8] = prescribed y-velocity value.
+    BT_top : ARRAY
+        Top temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_top[0] + BT_top[1]*T[i+1,j]
+    BT_bottom : ARRAY
+        Bottom temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_bottom[0] + BT_bottom[1]*T[i-1,j]
+    BT_left : ARRAY
+        Left temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_left[0] + BT_left[1]*T[i,j+1]
+    BT_right : ARRAY
+        Right temperature BCs.  Array has 2 columns, values in each are defined as:
+        T[i,j] = BT_right[0] + BT_right[1]*T[i,j-1]
+
+    '''
     
     # instantiate a pre-populated parameters object
     params = Parameters()
@@ -110,6 +168,27 @@ def initializeModel():
            
 
 def initialize_markers(markers, materials, params, xsize, ysize):
+    '''
+    Initialize the positions, material ID and temperature of the markers.
+    
+    Parameters
+    ----------
+    markers : Markers Object
+        An empty markers object, which will be filled by this function.
+        materials : Materials object
+        Materials object filled from file with the required materials.
+    params : Parameters Object
+        Contains the simulation parameters
+    xsize : FLOAT
+        Physical x-size of the simulation domain.
+    ysize : FLOAT
+        Physical y-size of the simulation domain.
+
+    Returns
+    -------
+    None.
+
+    '''
     
     # set the rough grid spacing for the markers
     mxstp = xsize/markers.xnum
@@ -137,3 +216,169 @@ def initialize_markers(markers, materials, params, xsize, ysize):
             
             # update marker index
             mm +=1
+            
+spec_par = [
+    ('gx', float64),
+    ('gy', float64),
+    ('Rgas', float64),
+    ('T_min', float64),
+    ('v_ext', float64),
+    ('eta_min', float64),
+    ('eta_max', float64),
+    ('stress_min', float64),
+    ('eta_wt', float64),
+    ('max_pow_law', float64),
+    ('t_end', float64),
+    ('ntstp_max', int64),
+    ('Temp_stp_max', int64),
+    ('tstp_max', float64),
+    ('marker_max', float64),
+    ('marker_sch', int64),
+    ('movemode', int64),
+    ('dsubgrid', float64),
+    ('dsubgridT', float64),
+    ('frict_yn', float64),
+    ('adia_yn', float64),
+    ('bx', float64),
+    ('by', float64),
+    ('Nx', int64),
+    ('Ny', int64),
+    ('non_uni_xsize', float64),
+    ('save_output', int64),
+    ('save_fig', int64),
+]
+@jitclass(spec_par)
+class Parameters():
+    '''
+    Class which holds the values of various physical and numerical parameters
+    required in the simulation.
+    
+    Attributes
+    ----------
+    gx : FLOAT
+        x-direction component of gravitational acceleration.
+    gy : FLOAT
+        y-direction component of gravitational acceleration.
+    Rgas : FLOAT
+        Ideal gas constant.
+    T_min : FLOAT
+        Minimum allowed temperature.
+    v_ext : FLOAT
+        Grid extension velocity, for deforming grid.
+    eta_min : FLOAT
+        Minimum allowed viscosity.
+    eta_max : FLOAT
+        Maximum allowed viscosity.
+    eta_wt : FLOAT
+        Weighting value for a (potentially not in use) visco-plastic model.
+    max_pow_law : FLOAT
+        Maximum allowed exponent in the power law viscosity model.
+    t_end : FLOAT
+        Time at which to end the simulation (if number of tsteps is less than ntstp_max).
+    ntstp_max : INT
+        Maximum number of timesteps to take.
+    Temp_stp_max : INT
+        Maximum number of temperature sub-timesteps to take.
+    tstp_max : FLOAT
+        Maximum size of timestep.
+    marker_max : FLOAT
+        Maximum fraction of average grid cell that a marker can move per timestep.
+    marker_sch : INT
+        Choice of advection scheme for markers, 1 = Euler, 4 = RK4
+    movemode : INT
+        Choice of how velocities are calculated, 0 = Stokes, no others implemented at present.
+    dsubgrid : FLOAT
+        Subgrid stress coefficient.
+    dsubgridT : FLOAT
+        Subgrid temperature diffusion coefficient.
+    frict_yn : FLOAT
+        Flag to apply friction heating.
+    adia_yn : FLOAT
+        Flag to apply adiabatic heating.
+    bx: FLOAT
+        x-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be xsize/(xnum-1).
+    by: FLOAT
+        y-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be ysize/(ynum-1).
+    Nx: INT
+        Number of uneven grid cells either side of the central high resolution 
+        region in the x-direction, for uniform grid this should be 0.
+    Ny: INT
+        Number of uneven grid cells below the high resolution 
+        region in the y-direction, for uniform grid this should be 0.
+    non_uni_size: FLOAT
+        Physical size of the non-uniform grid region in the x-direction.  For 
+        uniform grid this should be 0.
+    save_output : INT
+        Number of steps between output, not currently implemented.
+    save_fig : INT
+        Number of steps between plotting of figures.
+    
+    
+    '''
+    
+    
+    # creates parameters object
+    def __init__(self):
+        '''
+        Constructor for the parameters class
+        
+        Sets the default (lithsphere extension) values for all params
+
+        Returns
+        -------
+        None.
+
+        '''
+        # main parameters, required by all simulations
+        
+        # physical constants
+        self.gx = 0.0                           # x-direction gravitational acc
+        self.gy = 9.81                          # y-direction gravitational acc
+        self.Rgas = 8.314                       # gas constant
+        
+        # physical model setup
+        self.T_min = 273                        # temperature at the top face of the model (K)
+        
+        self.v_ext = 2.0/(100*365.25*24*3600)   # extension velocity of the grid (cm/yr)
+        
+        # viscosity model
+        self.eta_min = 1e18                     # minimum viscosity
+        self.eta_max = 1e25                     # maximum viscosity
+        self.stress_min = 1e4                   # minimum stress
+        self.eta_wt = 0                         # viscosity weighting, for (old?) visco-plastic model
+        self.max_pow_law = 150                  # maximum power law exponent in visc model
+        
+        
+        # timestepping
+        self.t_end = 72e3/self.v_ext            # end time
+        self.ntstp_max = 360                    # maximum number of timesteps
+        self.Temp_stp_max = 20                  # maximum number of temperature substeps
+        
+        self.tstp_max = 1e4*365.25*24*3600      # maximum timestep
+        
+        # marker options
+        self.marker_max = 0.3                   # maximum marker movement per timestep (fraction of av. grid step)
+        self.marker_sch = 4                     # marker scheme 0 = no movement, 1 = Euler, 4=RK4
+        
+        self.movemode = 0                       # velocity calculation 0 = momentum eqn, 1 = solid body (not working currently)
+        
+        # subgrid diffusion
+        self.dsubgrid = 1                       # subgrid stress coeff (none if zero)
+        self.dsubgridT = 1                      # subgrid diffusion coeff(none if zero)
+        
+        # switches for heating terms
+        self.frict_yn = 1                       # use friction heating?
+        self.adia_yn = 1                        # use adiabatic heating?
+        
+        # grid spacing params
+        self.bx = 2000                          # x-grid spacing in high res area
+        self.by = 2000                          # y-grid spacing in high res area
+        self.Nx = 30                            # number of unevenly spaced grid points either side of high res zone
+        self.Ny = 20                            # number of unvenly spaced grid points below high res zone
+        self.non_uni_xsize = 100000             # physical x-size of non-uniform grid region
+        
+        # output options
+        self.save_output = 50                        # number of steps between output files
+        self.save_fig = 20                            # number of steps between figure output

--- a/models/simpleStokesAndTempTest/setup.py
+++ b/models/simpleStokesAndTempTest/setup.py
@@ -5,9 +5,12 @@ Simple intrusion with visc, T,  density contrast
 """
 import numpy as np
 
-from dataStructures import Markers, Parameters, Grid, Materials
+from dataStructures import Markers, Grid, Materials
 from physics.grid_fns import gridSpacings
 import pathlib
+
+from numba import jit, float64, int64
+from numba.experimental import jitclass
 
 def initializeModel():
     '''
@@ -53,10 +56,10 @@ def initializeModel():
         Array defining optional internal boundary eg. moving wall. Format is:
         B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
         B_intern[1-2] = min/max y-index of the wall
-        B_intern[4] = prescribed x-velocity value.
-        B_intern[5] = y-index of vy nodes with prescribed velocity (-1 is not in use)
-        B_intern[6-7] = min/max x-index of the wall
-        B_intern[8] = prescribed y-velocity value.
+        B_intern[3] = prescribed x-velocity value.
+        B_intern[4] = x-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[5-6] = min/max y-index of the wall
+        B_intern[7] = prescribed y-velocity value.
     BT_top : ARRAY
         Top temperature BCs.  Array has 2 columns, values in each are defined as:
         T[i,j] = BT_top[0] + BT_top[1]*T[i+1,j]

--- a/models/simpleStokesAndTempTest/setup.py
+++ b/models/simpleStokesAndTempTest/setup.py
@@ -40,7 +40,7 @@ def initializeModel():
 
 
     # instantiate/load material properties object
-    matData = np.loadtxt('./models/simpleStokesTest/material_properties_simple.txt', skiprows=3, delimiter=",")
+    matData = np.loadtxt('./models/simpleStokesTest/material_properties_simple.txt', delimiter=",")
     materials = Materials(matData) 
 
     params.save_fig = 2

--- a/models/simpleStokesTest/setup.py
+++ b/models/simpleStokesTest/setup.py
@@ -55,10 +55,10 @@ def initializeModel():
         Array defining optional internal boundary eg. moving wall. Format is:
         B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
         B_intern[1-2] = min/max y-index of the wall
-        B_intern[4] = prescribed x-velocity value.
-        B_intern[5] = y-index of vy nodes with prescribed velocity (-1 is not in use)
-        B_intern[6-7] = min/max x-index of the wall
-        B_intern[8] = prescribed y-velocity value.
+        B_intern[3] = prescribed x-velocity value.
+        B_intern[4] = x-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[5-6] = min/max y-index of the wall
+        B_intern[7] = prescribed y-velocity value.
     BT_top : ARRAY
         Top temperature BCs.  Array has 2 columns, values in each are defined as:
         T[i,j] = BT_top[0] + BT_top[1]*T[i+1,j]

--- a/models/simpleStokesTest/setup.py
+++ b/models/simpleStokesTest/setup.py
@@ -5,9 +5,11 @@ Simple Stoke's flow test with constant visc, T and vertical density contrast
 """
 import numpy as np
 
-from dataStructures import Markers, Parameters, Grid, Materials
+from dataStructures import Markers, Grid, Materials
 from physics.grid_fns import gridSpacings
 import pathlib
+from numba import jit, float64, int64
+from numba.experimental import jitclass
 
 def initializeModel():
     '''
@@ -217,3 +219,170 @@ def initialize_markers(markers, materials, params, xsize, ysize):
             
             # update marker index
             mm +=1
+            
+            
+spec_par = [
+    ('gx', float64),
+    ('gy', float64),
+    ('Rgas', float64),
+    ('T_min', float64),
+    ('v_ext', float64),
+    ('eta_min', float64),
+    ('eta_max', float64),
+    ('stress_min', float64),
+    ('eta_wt', float64),
+    ('max_pow_law', float64),
+    ('t_end', float64),
+    ('ntstp_max', int64),
+    ('Temp_stp_max', int64),
+    ('tstp_max', float64),
+    ('marker_max', float64),
+    ('marker_sch', int64),
+    ('movemode', int64),
+    ('dsubgrid', float64),
+    ('dsubgridT', float64),
+    ('frict_yn', float64),
+    ('adia_yn', float64),
+    ('bx', float64),
+    ('by', float64),
+    ('Nx', int64),
+    ('Ny', int64),
+    ('non_uni_xsize', float64),
+    ('save_output', int64),
+    ('save_fig', int64),
+]
+@jitclass(spec_par)
+class Parameters():
+    '''
+    Class which holds the values of various physical and numerical parameters
+    required in the simulation.
+    
+    Attributes
+    ----------
+    gx : FLOAT
+        x-direction component of gravitational acceleration.
+    gy : FLOAT
+        y-direction component of gravitational acceleration.
+    Rgas : FLOAT
+        Ideal gas constant.
+    T_min : FLOAT
+        Minimum allowed temperature.
+    v_ext : FLOAT
+        Grid extension velocity, for deforming grid.
+    eta_min : FLOAT
+        Minimum allowed viscosity.
+    eta_max : FLOAT
+        Maximum allowed viscosity.
+    eta_wt : FLOAT
+        Weighting value for a (potentially not in use) visco-plastic model.
+    max_pow_law : FLOAT
+        Maximum allowed exponent in the power law viscosity model.
+    t_end : FLOAT
+        Time at which to end the simulation (if number of tsteps is less than ntstp_max).
+    ntstp_max : INT
+        Maximum number of timesteps to take.
+    Temp_stp_max : INT
+        Maximum number of temperature sub-timesteps to take.
+    tstp_max : FLOAT
+        Maximum size of timestep.
+    marker_max : FLOAT
+        Maximum fraction of average grid cell that a marker can move per timestep.
+    marker_sch : INT
+        Choice of advection scheme for markers, 1 = Euler, 4 = RK4
+    movemode : INT
+        Choice of how velocities are calculated, 0 = Stokes, no others implemented at present.
+    dsubgrid : FLOAT
+        Subgrid stress coefficient.
+    dsubgridT : FLOAT
+        Subgrid temperature diffusion coefficient.
+    frict_yn : FLOAT
+        Flag to apply friction heating.
+    adia_yn : FLOAT
+        Flag to apply adiabatic heating.
+    bx: FLOAT
+        x-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be xsize/(xnum-1).
+    by: FLOAT
+        y-grid spacing in the high resolution region of the grid.  For uniform grid
+        this should be ysize/(ynum-1).
+    Nx: INT
+        Number of uneven grid cells either side of the central high resolution 
+        region in the x-direction, for uniform grid this should be 0.
+    Ny: INT
+        Number of uneven grid cells below the high resolution 
+        region in the y-direction, for uniform grid this should be 0.
+    non_uni_size: FLOAT
+        Physical size of the non-uniform grid region in the x-direction.  For 
+        uniform grid this should be 0.
+    save_output : INT
+        Number of steps between output, not currently implemented.
+    save_fig : INT
+        Number of steps between plotting of figures.
+    
+    
+    '''
+    
+    
+    # creates parameters object
+    def __init__(self):
+        '''
+        Constructor for the parameters class
+        
+        Sets the default (lithsphere extension) values for all params
+
+        Returns
+        -------
+        None.
+
+        '''
+        # main parameters, required by all simulations
+        
+        # physical constants
+        self.gx = 0.0                           # x-direction gravitational acc
+        self.gy = 9.81                          # y-direction gravitational acc
+        self.Rgas = 8.314                       # gas constant
+        
+        # physical model setup
+        self.T_min = 273                        # temperature at the top face of the model (K)
+        
+        self.v_ext = 2.0/(100*365.25*24*3600)   # extension velocity of the grid (cm/yr)
+        
+        # viscosity model
+        self.eta_min = 1e18                     # minimum viscosity
+        self.eta_max = 1e25                     # maximum viscosity
+        self.stress_min = 1e4                   # minimum stress
+        self.eta_wt = 0                         # viscosity weighting, for (old?) visco-plastic model
+        self.max_pow_law = 150                  # maximum power law exponent in visc model
+        
+        
+        # timestepping
+        self.t_end = 72e3/self.v_ext            # end time
+        self.ntstp_max = 360                    # maximum number of timesteps
+        self.Temp_stp_max = 20                  # maximum number of temperature substeps
+        
+        self.tstp_max = 1e4*365.25*24*3600      # maximum timestep
+        
+        # marker options
+        self.marker_max = 0.3                   # maximum marker movement per timestep (fraction of av. grid step)
+        self.marker_sch = 4                     # marker scheme 0 = no movement, 1 = Euler, 4=RK4
+        
+        self.movemode = 0                       # velocity calculation 0 = momentum eqn, 1 = solid body (not working currently)
+        
+        # subgrid diffusion
+        self.dsubgrid = 1                       # subgrid stress coeff (none if zero)
+        self.dsubgridT = 1                      # subgrid diffusion coeff(none if zero)
+        
+        # switches for heating terms
+        self.frict_yn = 1                       # use friction heating?
+        self.adia_yn = 1                        # use adiabatic heating?
+        
+        # grid spacing params
+        self.bx = 2000                          # x-grid spacing in high res area
+        self.by = 2000                          # y-grid spacing in high res area
+        self.Nx = 30                            # number of unevenly spaced grid points either side of high res zone
+        self.Ny = 20                            # number of unvenly spaced grid points below high res zone
+        self.non_uni_xsize = 100000             # physical x-size of non-uniform grid region
+        
+        # output options
+        self.save_output = 50                        # number of steps between output files
+        self.save_fig = 20                            # number of steps between figure output

--- a/models/simpleStokesTest/setup.py
+++ b/models/simpleStokesTest/setup.py
@@ -98,7 +98,7 @@ def initializeModel():
 
 
     # instantiate/load material properties object
-    matData = np.loadtxt('./models/simpleStokesTest/material_properties_simple.txt', skiprows=3, delimiter=",")
+    matData = np.loadtxt('./models/simpleStokesTest/material_properties_simple.txt', delimiter=",")
     materials = Materials(matData) 
 
     # output options

--- a/physics/StokesContinuitySolver.py
+++ b/physics/StokesContinuitySolver.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""
+Stokes and Continuity equations solver.  
 
+Uses scipy's sparse arrays and sparse direct matrix solver to solve the Stokes and Continuity equations in 2D.
+
+"""
 import numpy as np
 from scipy.sparse import bsr_matrix, csr_matrix, coo_array
 from scipy.sparse.linalg import spsolve
@@ -765,7 +770,7 @@ def StokesContinuitySolver(P_first, eta_s, eta_n, xnum, ynum, gridx, gridy, R_x,
 @jit
 def calculateResiduals(xnum, ynum, xstp, xstpc, ystp, ystpc, eta_s, eta_n, vx, vy, P, R_x, R_y, R_C, B_intern):
     '''
-    
+    Calculates the residuals of the Stoke's solver.
 
     Parameters
     ----------

--- a/physics/StokesContinuitySolver.py
+++ b/physics/StokesContinuitySolver.py
@@ -197,10 +197,10 @@ def StokesConstructMatrix(xnum, ynum, xstp, xstpc, ystp, ystpc, xstp_av, ystp_av
         Array defining optional internal boundary eg. moving wall. Format is:
         B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
         B_intern[1-2] = min/max y-index of the wall
-        B_intern[4] = prescribed x-velocity value.
-        B_intern[5] = y-index of vy nodes with prescribed velocity (-1 is not in use)
-        B_intern[6-7] = min/max x-index of the wall
-        B_intern[8] = prescribed y-velocity value.
+        B_intern[3] = prescribed x-velocity value.
+        B_intern[4] = x-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[5-6] = min/max y-index of the wall
+        B_intern[7] = prescribed y-velocity value.
 
     Returns
     -------
@@ -688,10 +688,10 @@ def StokesContinuitySolver(P_first, eta_s, eta_n, xnum, ynum, gridx, gridy, R_x,
         Array defining optional internal boundary eg. moving wall. Format is:
         B_intern[0] = x-index of vx nodes with prescribed velocity (-1 is not in use)
         B_intern[1-2] = min/max y-index of the wall
-        B_intern[4] = prescribed x-velocity value.
-        B_intern[5] = y-index of vy nodes with prescribed velocity (-1 is not in use)
-        B_intern[6-7] = min/max x-index of the wall
-        B_intern[8] = prescribed y-velocity value.
+        B_intern[3] = prescribed x-velocity value.
+        B_intern[4] = x-index of vy nodes with prescribed velocity (-1 is not in use)
+        B_intern[5-6] = min/max y-index of the wall
+        B_intern[7] = prescribed y-velocity value.
 
     Returns
     -------
@@ -826,7 +826,7 @@ def calculateResiduals(xnum, ynum, xstp, xstpc, ystp, ystpc, eta_s, eta_n, vx, v
         for j in range(0, xnum+1):
             ####################################################################
             # x Stokes eqn
-            if (j<xnum and (j!=B_intern[0] or i<B_intern[1] or i>B_intern[3])):
+            if (j<xnum and (j!=B_intern[0] or i<B_intern[1] or i>B_intern[2])):
                 if (i==0 or i==ynum or j==0 or j==xnum-1):
                     resx[i,j] = 0
                 else:

--- a/physics/TemperatureSolver.py
+++ b/physics/TemperatureSolver.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-'''
- Function Temperature_solver_grid()
- This file contains the above function which formulates and solves  
- Heat conservation equation defined on 2D irregularly spaced grid
- with specified resolution (xnum, ynum) and grid lines positions (gridx, gridy)
- given distribution of right parts for all equations (RT) on the grid 
- and given RHO*CP and k values
- 
+"""
+Temperature equation solver.  
 
-'''
+Uses scipy's sparse arrays and sparse direct matrix solver to solve the temperature equation in 2D.
+
+"""
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -320,7 +316,7 @@ def TemperatureSolver(tstep, xnum, ynum, gridx, gridy, kt, rho_Cp, B_top, B_bott
 @jit
 def calculateResiduals(xnum, ynum, xstp, xstpc, ystp, ystpc, rho_Cp, T_k_new, T_k, kt, R_heat, tstep):
     '''
-    
+    Calculates the residuals of the solver.
 
     Parameters
     ----------

--- a/physics/grid_fns.py
+++ b/physics/grid_fns.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-fns for calculating visco-elastic stresses, strain rates and grid spacings
+Functions for calculating grid-based properties such as visco-elastic stresses, strain rates and grid spacings.
 """
 import numpy as np
 from numba import jit

--- a/physics/markerUtils.py
+++ b/physics/markerUtils.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-marker utilities - low level functions for marker calculations
+Low level functions for marker calculations, including marker-to-grid/grid-to-marker interpolation, and finding nearest node distances.
 
 """
 import numpy as np
-from dataStructures import Markers, Materials, Grid, Parameters
+from dataStructures import Markers, Materials, Grid
 from numba import jit
 
 @jit(nopython=True)

--- a/physics/markers_fns.py
+++ b/physics/markers_fns.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-functions that relate to marker physics,
+Functions that relate to marker physics,
 including interpolation of quantities to/from the grid,
 marker viscosity calculation, subgrid stress/diffusion
 
-lower level functions for marker operations, including getting nearest node 
-distances, interpolating a value to/from markers, etc. are in markerUtils.py
+Lower level functions for marker operations, including getting nearest node 
+distances, interpolating a value to/from markers, etc. are in markerUtils.
 
 """
 import numpy as np
 from numba import jit
 
-from dataStructures import Markers, Materials, Grid, Parameters
+from dataStructures import Markers, Materials, Grid
 from physics.markerUtils import applyGridContrib, applyMarkerContrib,\
     getMarkerNodeDistances, findNearestNode, applyGridWeights
 
@@ -173,8 +173,8 @@ def markerViscosity(markers, materials, m, grid, params, ntstp, tstep, plast_y):
         
         # check marker temp
         T_pow_law = markers.T[m]
-        if (T_pow_law < params.T_top):
-            T_pow_law = params.T_top
+        if (T_pow_law < params.T_min):
+            T_pow_law = params.T_min
         
         # compute exponential term
         pow_law_exp = (materials.visc[mID,4] + materials.visc[mID,5]*markers.P[m])/(params.Rgas*T_pow_law)
@@ -512,6 +512,7 @@ def subgridDiffusion(grid, markers, params, xnum, ynum, timestep, xstp_av, ystp_
         Average grid spacing in x-direction.
     ystp_av : FLOAT
         Average grid spacing in y-direction.
+    
     Returns
     -------
     dTn : ARRAY

--- a/visualisation.py
+++ b/visualisation.py
@@ -84,7 +84,7 @@ def plotAVar(grid, vxb, vyb, L_x, L_y, ntstp, t_curr):
     im = axs.pcolor(X, Y, grid.rho, shading='nearest', vmin=1000, vmax=3300)
     fig.colorbar(im, ax=axs,pad=0.0) # display colorbar
     axs.set_title('Density')     # set plot title
-    axs.set(ylabel='y (km)')         # label the y-axis (shared axis for x)
+    axs.set(ylabel='y (m)',xlabel='x (m)')         # label the y-axis (shared axis for x)
     qu = axs.quiver(grid.x, grid.y, vxb[:yres,:], np.flip(-vyb[:,:xres],0)) 
     axs.invert_yaxis()
 
@@ -136,7 +136,7 @@ def plotSeveralVars(grid, vxb, vyb, L_x, L_y, ntstp, t_curr):
     im = axs[0,0].pcolor(X, Y, grid.rho, shading='nearest', vmin=1000, vmax=3300)
     fig.colorbar(im, ax=axs[0,0],pad=0.0) # display colorbar
     axs[0,0].set_title('Density')     # set plot title
-    axs[0,0].set(ylabel='y (km)')         # label the y-axis (shared axis for x)
+    axs[0,0].set(ylabel='y (m)')         # label the y-axis (shared axis for x)
     
     qu = axs[0,0].quiver(grid.x, grid.y, vxb[:yres,:], np.flip(-vyb[:,:xres],0)) 
     axs[0,0].invert_yaxis()
@@ -150,13 +150,13 @@ def plotSeveralVars(grid, vxb, vyb, L_x, L_y, ntstp, t_curr):
     im = axs[1,0].pcolor(X, Y, vxb, shading='nearest',vmin=-5e-10, vmax=5e-10)
     fig.colorbar(im, ax=axs[1,0],pad=0.0) # display colorbar
     axs[1,0].set_title('Vx')     # set plot title
-    axs[1,0].set(ylabel='y (km)', xlabel='x (km)')         # label the y-axis (shared axis for x)
+    axs[1,0].set(ylabel='y (m)', xlabel='x (m)')         # label the y-axis (shared axis for x)
 
     # plot vy as colormap
     im = axs[1,1].pcolor(X, Y, vyb, shading='nearest',vmin=-5e-10, vmax=5e-10)
     fig.colorbar(im, ax=axs[1,1],pad=0.0) # display colorbar
     axs[1,1].set_title('Vy')     # set plot title
-    axs[1,1].set(xlabel='x (km)')         
+    axs[1,1].set(xlabel='x (m)')         
     
     # T
     im = axs[0,2].pcolor(X, Y, grid.T, shading='nearest',vmin=273, vmax=1800)
@@ -167,6 +167,7 @@ def plotSeveralVars(grid, vxb, vyb, L_x, L_y, ntstp, t_curr):
     im = axs[1,2].pcolor(X, Y, np.log10(grid.eta_s),vmin=18, vmax=25)
     fig.colorbar(im, ax=axs[1,2],pad=0.0) # display colorbar
     axs[1,2].set_title('Viscosity')     # set plot title
+    axs[1,2].set(xlabel='x (m)') 
     
     fig.suptitle('Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600)))
 

--- a/visualisation.py
+++ b/visualisation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Visualisation routines
+Visualisation routines for plotting code output
 
 """
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Major changes
- Added some basic documentation using Sphinx.  To build the documentation:
     - install sphinx, with `pip` or `conda`
     - Navigate to the docs directory, then run `make html`
     - A directory called `build` should appear, you can then access the documentation by opening the `index.html` file in this directory.

 - Moved the `Parameters` class definition into `setup.py`.  Since `jitclass` does not support inheritance, this should make it easier for users to add a new attribute to the class for their model only.

 - Added `T_min` to `Parameters`, which is used in `markerViscosity` to limit the power law in case of very low T.  In the lithosphere extension model, `T_top` was used for this, but in general this won't always be true.

## Smaller changes
 - Added docstrings to class definitions and made updates to various function docstrings.
 - Added a small example model, `internalVelocityExample`, which demonstrates the behaviour of the `B_intern` internal velocity boundary.
 - Added a Contributors file.
- Fixed axis labels on plots.