### PR TITLE
Plot titles

### DIFF
--- a/models/Subduction/visualisation.py
+++ b/models/Subduction/visualisation.py
@@ -13,7 +13,7 @@ from output.visualisation import getMarkerField, getMarkerPixelGrid, plotMarkers
 ###############################################################################
 # custom plotting routines
 
-def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
+def plotMarkers_stress(params, markers, grid, ntstp, t_curr, xres):
     '''
     Plot the stress components recorded by the markers.
 
@@ -29,6 +29,8 @@ def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
         Current timestep number.
     t_curr : FLOAT
         Current time (s).
+    xres : INT
+        Number of pixels in the x-direction (y is set from this according to ratio of xsize/ysize).
 
     Returns
     -------
@@ -37,7 +39,7 @@ def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
     '''
     
     # get the mapping of markers to pixel positions
-    marker_map = getMarkerPixelGrid(params, markers, grid, 401)
+    marker_map = getMarkerPixelGrid(params, markers, grid, xres)
     
     # get the specific fields we want here
     mark_sigmaxx = getMarkerField(marker_map, markers.sigmaxx)
@@ -95,7 +97,7 @@ def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
 
 
     
-def plotMarkers_strain(params, markers, grid, ntstp, t_curr):
+def plotMarkers_strain(params, markers, grid, ntstp, t_curr, xres):
     '''
     Plot the strain components and accumulated strain recorded by the markers.
 
@@ -111,6 +113,8 @@ def plotMarkers_strain(params, markers, grid, ntstp, t_curr):
         Current timestep number.
     t_curr : FLOAT
         Current time (s).
+    xres : INT
+        Number of pixels in the x-direction (y is set from this according to ratio of xsize/ysize).
 
     Returns
     -------
@@ -119,7 +123,7 @@ def plotMarkers_strain(params, markers, grid, ntstp, t_curr):
     '''
     
     # get the mapping of markers to pixel positions
-    marker_map = getMarkerPixelGrid(params, markers, grid, 401)
+    marker_map = getMarkerPixelGrid(params, markers, grid, xres)
 
     box_size = [0,params.xsize,params.ysize,0]
     
@@ -219,12 +223,16 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     """
     xlims = (0,550e3)
     ylims = (300e3,0)
+    title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
     
-    plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, aspect_ratio=3)
-    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, aspect_ratio=3, plotTempContours=True, temp_levels=[100, 150, 350, 450, 1300])
-    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, aspect_ratio=3)
-    plotMarkers_strain(params, markers, grid, ntstp, t_curr)
-    plotMarkers_stress(params, markers, grid, ntstp, t_curr)
+    # resolution for the markers plots
+    xres = 801
+    
+    plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, title, aspect_ratio=3)
+    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title, aspect_ratio=3, plotTempContours=True, temp_levels=[100, 150, 350, 450, 1300])
+    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, aspect_ratio=3)
+    plotMarkers_strain(params, markers, grid, ntstp, t_curr, xres)
+    plotMarkers_stress(params, markers, grid, ntstp, t_curr, xres)
 
     
     

--- a/models/internalVelocityExample/visualisation.py
+++ b/models/internalVelocityExample/visualisation.py
@@ -32,10 +32,12 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     """
     xlims = (0,params.xsize)
     ylims = (params.ysize,0)
+    title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
+    xres = 401
     
     
-    plotSummary(grid, params, ntstp, t_curr, xlims, ylims)
-    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, height=6)
+    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title)
+    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, height=6)
     
     
     

--- a/models/lithosphereExtension/visualisation.py
+++ b/models/lithosphereExtension/visualisation.py
@@ -12,7 +12,7 @@ from output.visualisation import getMarkerField, getMarkerPixelGrid, plotMarkers
 ###############################################################################
 # custom plotting routines
 
-def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
+def plotMarkers_stress(params, markers, grid, ntstp, t_curr, xres):
     '''
     Plot the stress components recorded by the markers.
 
@@ -39,7 +39,7 @@ def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
     ylims = (grid.y[-1], grid.y[0])
     
     # get the mapping of markers to pixel positions
-    marker_map = getMarkerPixelGrid(params, markers, grid, 401)
+    marker_map = getMarkerPixelGrid(params, markers, grid, xres)
     
     # get the specific fields we want here
     mark_sigmaxx = getMarkerField(marker_map, markers.sigmaxx)
@@ -97,7 +97,7 @@ def plotMarkers_stress(params, markers, grid, ntstp, t_curr):
 
 
     
-def plotMarkers_strain(params, markers, grid, ntstp, t_curr):
+def plotMarkers_strain(params, markers, grid, ntstp, t_curr, xres):
     '''
     Plot the strain components and accumulated strain recorded by the markers.
 
@@ -121,7 +121,7 @@ def plotMarkers_strain(params, markers, grid, ntstp, t_curr):
     '''
     
     # get the mapping of markers to pixel positions
-    marker_map = getMarkerPixelGrid(params, markers, grid, 401)
+    marker_map = getMarkerPixelGrid(params, markers, grid, xres)
 
     
     xlims = (grid.x[0], grid.x[-1])
@@ -224,9 +224,13 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     """
     xlims = (grid.x[0], grid.x[-1])
     ylims = (grid.y[-1], grid.y[0])
+    title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
     
-    plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, aspect_ratio=3)
-    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, aspect_ratio=3, plotTempContours=True, temp_levels=[100, 150, 350, 450, 1300])
-    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, aspect_ratio=3)
-    plotMarkers_strain(params, markers, grid, ntstp, t_curr)
-    plotMarkers_stress(params, markers, grid, ntstp, t_curr)
+    # resolution for the markers plots
+    xres = 801
+    
+    plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, title, aspect_ratio=3)
+    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title, aspect_ratio=3, plotTempContours=True, temp_levels=[100, 150, 350, 450, 1300])
+    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, aspect_ratio=3)
+    plotMarkers_strain(params, markers, grid, ntstp, t_curr, xres)
+    plotMarkers_stress(params, markers, grid, ntstp, t_curr, xres)

--- a/models/simpleStokes/visualisation.py
+++ b/models/simpleStokes/visualisation.py
@@ -37,7 +37,7 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
     
     # resolution for the markers plots
-    xres = 801
+    xres = 401
     
     plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title, rhomin=3200, rhomax=3300, vmin=19, vmax=21, Pmin=1e6, Pmax=1e9)
     plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, height=6, plot_vel_arrows=True)

--- a/models/simpleStokes/visualisation.py
+++ b/models/simpleStokes/visualisation.py
@@ -34,8 +34,12 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     xlims = (0,params.xsize)
     ylims = (params.ysize,0)
     
+    title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
     
-    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, rhomin=3200, rhomax=3300, vmin=19, vmax=21, Pmin=1e6, Pmax=1e9)
-    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, height=6, plot_vel_arrows=True)
+    # resolution for the markers plots
+    xres = 801
+    
+    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title, rhomin=3200, rhomax=3300, vmin=19, vmax=21, Pmin=1e6, Pmax=1e9)
+    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, height=6, plot_vel_arrows=True)
     
     

--- a/models/simpleStokesAndTemp/visualisation.py
+++ b/models/simpleStokesAndTemp/visualisation.py
@@ -36,7 +36,7 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
     
     # resolution for the markers plots
-    xres = 801
+    xres = 401
     
     plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title, rhomin=3200, rhomax=3300, vmin=19, vmax=21)
     plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, height=6)

--- a/models/simpleStokesAndTemp/visualisation.py
+++ b/models/simpleStokesAndTemp/visualisation.py
@@ -33,11 +33,14 @@ def makePlots(grid, markers, params, ntstp, t_curr):
     """
     xlims = (0,params.xsize)
     ylims = (params.ysize,0)
+    title = 'Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600))
     
+    # resolution for the markers plots
+    xres = 801
     
-    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, rhomin=3200, rhomax=3300, vmin=19, vmax=21)
-    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, height=6)
-    plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, height=6, Tmin=1000, Tmax=1100)
+    plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title, rhomin=3200, rhomax=3300, vmin=19, vmax=21)
+    plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, height=6)
+    plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, title, height=6, Tmin=1000, Tmax=1100)
 
 
     

--- a/output/visualisation.py
+++ b/output/visualisation.py
@@ -14,7 +14,7 @@ from solver.physics.grid_fns import basicGridVelocities
 ###############################################################################
 # fns for plotting from the Grid
 
-def plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, 
+def plotTemperature(grid, params, ntstp, t_curr, xlims, ylims, title,
                     aspect_ratio=None, height=None, plot_vel_arrows=False, arrow_stp = 5, Tmin=0.0, Tmax=1400.0):
     '''
     Plot a single variable as a colormap, here it is the temperature but this serves as 
@@ -31,6 +31,12 @@ def plotTemperature(grid, params, ntstp, t_curr, xlims, ylims,
         Current timestep number.
     t_curr : FLOAT
         Current time (s).
+    xlims : TUPLE
+        Limits of plotting area in the x-direction.
+    ylims : TUPLE
+        Limits of plotting area in the y-direction.
+    title : STR
+        Title to give to plot.
     aspect_ratio : FLOAT (OPTIONAL)
         Option to manually set the aspect ratio of the plots.
     height : FLOAT (OPTIONAL)
@@ -93,13 +99,13 @@ def plotTemperature(grid, params, ntstp, t_curr, xlims, ylims,
     axs.set_title('Temperature (C)')                                             # set plot title
     axs.set(ylabel='y (m)', xlabel='x (m)', xlim=xlims, ylim=ylims)  # label the y-axis and x-axis
     #axs.invert_yaxis() 
-    fig.suptitle('Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600)))
+    fig.suptitle(title)
     
     # save to file 
     fig.savefig('%s/%s/temp_%i.png'%(params.output_path, params.output_name, ntstp))
 
 
-def plotSummary(grid, params, ntstp, t_curr, xlims, ylims,
+def plotSummary(grid, params, ntstp, t_curr, xlims, ylims, title,
                 aspect_ratio=None, plotTempContours=False, temp_levels=None,
                 rhomin=2200, rhomax=3500, vmin=18, vmax=28, Pmin=1.0e8, Pmax=.09e9):
     '''
@@ -116,6 +122,12 @@ def plotSummary(grid, params, ntstp, t_curr, xlims, ylims,
         Current timestep number.
     t_curr : FLOAT
         Current time (s).
+    xlims : TUPLE
+        Limits of plotting area in the x-direction.
+    ylims : TUPLE
+        Limits of plotting area in the y-direction.
+    title : STR
+        Title to give to plot.
     aspect_ratio : FLOAT (OPTIONAL)
         Option to manually set the aspect ratio of the plots.
     plotTempContours : BOOL (OPTIONAL)
@@ -221,7 +233,7 @@ def plotSummary(grid, params, ntstp, t_curr, xlims, ylims,
         axs[2].clabel(cs, inline=True, fontsize=8, fmt='%d C')
 
 
-    fig.suptitle('Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600)))
+    fig.suptitle(title)
     fig.savefig('%s/%s/summary_%i.png'%(params.output_path, params.output_name, ntstp))
     
 
@@ -354,8 +366,8 @@ def getMarkerField(mark_nums, markers_field):
 
 
 
-def plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, 
-                          aspect_ratio=None, height=None, plot_vel_arrows=False, title="Lithology"):
+def plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims, title, xres, 
+                          aspect_ratio=None, height=None, plot_vel_arrows=False):
     '''
     Plot the lithology/material ID recorded by the markers.
 
@@ -375,14 +387,17 @@ def plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims,
         Limits of plotting area in the x-direction.
     ylims : TUPLE
         Limits of plotting area in the y-direction.
+    title : STR
+        Title to give to plot.
+    xres : INT
+        Number of pixels in the x-direction (y is set from this according to ratio of xsize/ysize).
     aspect_ratio : FLOAT (OPTIONAL)
         Option to manually set the aspect ratio of the plots.
     height : FLOAT (OPTIONAL)
         Option to manually set height of an axis.
     plot_vel_arrows : BOOL (Optional)
         Option to plot velocity arrows on the image, default is False.
-    title : STR (OPTIONAL)
-        Title to give to plot. Default is "Lithology".
+    
     
     Returns
     -------
@@ -391,7 +406,7 @@ def plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims,
     '''
 
     # get the mapping of markers to pixel positions
-    marker_map = getMarkerPixelGrid(params, markers, grid, 401)
+    marker_map = getMarkerPixelGrid(params, markers, grid, xres)
     mark_com = getMarkerField(marker_map, markers.id)
 
     # get aspect ratio
@@ -438,7 +453,7 @@ def plotMarkers_lithology(params, markers, grid, ntstp, t_curr, xlims, ylims,
         axs.quiver(X[::arrow_stp, ::arrow_stp], Y[::arrow_stp, ::arrow_stp],\
                       vxb[:grid.ynum,:][::arrow_stp, ::arrow_stp], np.flip(-vyb[:,:grid.xnum],0)[::arrow_stp, ::arrow_stp])	            
     
-    fig.suptitle('Time: %.3f Myr'%(t_curr*1e-6/(365.25*24*3600)))
+    fig.suptitle(title)
     fig.savefig('%s/%s/litho_%i.png'%(params.output_path, params.output_name, ntstp))
     
     


### PR DESCRIPTION
- Added `title` as argument for plotting function in `output/visualisations.py` to allow users to specify units of time in the title manually.
- Added `xres` argument to `plotMarkers_lithology`, to allow the pixel resolution of the plot to be specified. 
- Updated examples to use this new syntax.